### PR TITLE
Upgrade Travis Ubuntu distribution to bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.7
   - 3.6
-dist: trusty
+dist: bionic
 
 env:
   # Need this environment if we're doing tests without a config file

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.7
   - 3.6
-dist: bionic
+dist: focal
 
 env:
   # Need this environment if we're doing tests without a config file


### PR DESCRIPTION
Upgrading Travis Ubuntu distribution to 18.04 (bionic) to help us with binaries that are close to the ITCM limit.

See https://github.com/orgs/SpiNNakerManchester/projects/32 for full list of PRs.