### PR TITLE
Graph mapper has been removed; simulation.h not needed...

### DIFF
--- a/c_models/mcmc_models/src/mcmc.c
+++ b/c_models/mcmc_models/src/mcmc.c
@@ -25,7 +25,6 @@
 #include <limits.h>
 #include <spin1_api.h>
 #include <data_specification.h>
-#include <simulation.h>
 #include <recording.h>
 #include <debug.h>
 #include "mcmc_model.h"

--- a/mcmc/mcmc_coordinator_vertex.py
+++ b/mcmc/mcmc_coordinator_vertex.py
@@ -262,7 +262,7 @@ class MCMCCoordinatorVertex(
         spec.end_specification()
 
     @overrides(AbstractProvidesNKeysForPartition.get_n_keys_for_partition)
-    def get_n_keys_for_partition(self, partition, graph_mapper):
+    def get_n_keys_for_partition(self, partition):
         return self._n_sequences
 
     def read_samples(self, buffer_manager):


### PR DESCRIPTION
Updating MCMC to match graph mapper removal in main software tools.