### PR TITLE
SpiNNStorageHandlers and AbstractProvidesNKeysForPartition have gone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: python
 python:
   - 2.7
   - 3.6
+  - 3.7
+  - 3.8
 dist: focal
-
-env:
-  # Need this environment if we're doing tests without a config file
-  - READTHEDOCS=True
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
   # SpiNNakerManchester internal dependencies; development mode
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNUtils.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNMachine.git
-  - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNStorageHandlers.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNMan.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/PACMAN.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/DataSpecification.git

--- a/mcmc/mcmc_coordinator_vertex.py
+++ b/mcmc/mcmc_coordinator_vertex.py
@@ -10,9 +10,6 @@ from spinn_front_end_common.abstract_models.abstract_has_associated_binary \
 from spinn_front_end_common.abstract_models\
     .abstract_generates_data_specification \
     import AbstractGeneratesDataSpecification
-from spinn_front_end_common.abstract_models\
-    .abstract_provides_n_keys_for_partition \
-    import AbstractProvidesNKeysForPartition
 from spinn_front_end_common.utilities.utility_objs.executable_type \
     import ExecutableType
 
@@ -24,8 +21,7 @@ import random
 
 class MCMCCoordinatorVertex(
         MachineVertex, AbstractHasAssociatedBinary,
-        AbstractGeneratesDataSpecification,
-        AbstractProvidesNKeysForPartition):
+        AbstractGeneratesDataSpecification):
     """ A vertex that runs the MCMC algorithm
     """
 
@@ -60,7 +56,8 @@ class MCMCCoordinatorVertex(
         :param seed: The random seed to use
         """
 
-        MachineVertex.__init__(self, label="MCMC Node", constraints=None)
+        MachineVertex.__init__(self, label="MCMC Coordinator Node",
+                               constraints=None)
         self._model = model
         self._data = data
         self._n_samples = n_samples
@@ -261,7 +258,6 @@ class MCMCCoordinatorVertex(
         # End the specification
         spec.end_specification()
 
-    @overrides(AbstractProvidesNKeysForPartition.get_n_keys_for_partition)
     def get_n_keys_for_partition(self, partition):
         return self._n_sequences
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 SpiNNUtilities >= 1!5.0.1, < 1!6.0.0
 SpiNNMachine >= 1!5.0.1, < 1!6.0.0
-SpiNNStorageHandlers >= 1!5.0.1, < 1!6.0.0
 SpiNNMan >= 1!5.0.1, < 1!6.0.0
 SpiNNaker_PACMAN >= 1!5.0.1, < 1!6.0.0
 SpiNNaker_DataSpecification >= 1!5.0.1, < 1!6.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     packages=packages,
     package_data=package_data,
     install_requires=['SpiNNUtilities >= 1!5.0.1, < 1!6.0.0',
-                      'SpiNNStorageHandlers >= 1!5.0.1, < 1!6.0.0',
                       'SpiNNMachine >= 1!5.0.1, < 1!6.0.0',
                       'SpiNNMan >= 1!5.0.1, < 1!6.0.0',
                       'SpiNNaker_PACMAN >= 1!5.0.1, < 1!6.0.0',


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/MarkovChainMonteCarlo/issues/15

SpiNNStorageHandlers repository has been archived, and AbstractProvidesNKeysForPartition no longer exists, so removing them.
